### PR TITLE
Directly link to the beginning of the instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ This repository contains guides for how to set-up IRCRelay with your client.
 
 Currently, we have guides for the following clients:
 
-- [Textual](/ircrelay/ircrelay-client-guides/blob/master/guides/textual/guide.md#textual-ircrelay-set-up-guide)
-- [Colloquy](/ircrelay/ircrelay-client-guides/blob/master/guides/colloquy/guide.md#colloquy-ircrelay-set-up-guide)
-- [Limechat](/ircrelay/ircrelay-client-guides/blob/master/guides/limechat/guide.md#limechat-ircrelay-set-up-guide)
-- [Linkinus](/ircrelay/ircrelay-client-guides/blob/master/guides/linkinus/guide.md#linkinus-ircrelay-set-up-guide)
-- [irssi](/ircrelay/ircrelay-client-guides/blob/master/guides/irssi/guide.md#irssi-ircrelay-set-up-guide)
+- [Textual](https://github.com/ircrelay/ircrelay-client-guides/blob/master/guides/textual/guide.md#textual-ircrelay-set-up-guide)
+- [Colloquy](https://github.com/ircrelay/ircrelay-client-guides/blob/master/guides/colloquy/guide.md#colloquy-ircrelay-set-up-guide)
+- [Limechat](https://github.com/ircrelay/ircrelay-client-guides/blob/master/guides/limechat/guide.md#limechat-ircrelay-set-up-guide)
+- [Linkinus](https://github.com/ircrelay/ircrelay-client-guides/blob/master/guides/linkinus/guide.md#linkinus-ircrelay-set-up-guide)
+- [irssi](https://github.com/ircrelay/ircrelay-client-guides/blob/master/guides/irssi/guide.md#irssi-ircrelay-set-up-guide)
 
 ## Contributing
 


### PR DESCRIPTION
I actually edited the Readme to go to the full URL of the docs but missed the # section so I've added that to this and closed the other pull request since they weren't automatically added together.
